### PR TITLE
Added SPI dependency in library.json file

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,5 +15,11 @@
   "frameworks": [
         "arduino"
   ],
-  "platforms": "*"
+  "platforms": "*",
+  "dependencies":
+  [
+      {
+          "name": "SPI"
+      }
+  ]
 }


### PR DESCRIPTION
In order to use this library in ESP Home I had to specify the SPI requirement for it to compile.